### PR TITLE
Escape windows "\" when loading path patterns

### DIFF
--- a/las_trx/__main__.py
+++ b/las_trx/__main__.py
@@ -334,11 +334,11 @@ class MainWindow(QMainWindow):
 
     @property
     def input_pattern(self) -> str:
-        return self.cw.lineEdit_input_file.text()
+        return rf"{self.cw.lineEdit_input_file.text()}"
 
     @property
     def output_pattern(self) -> str:
-        return self.cw.lineEdit_output_file.text()
+        return rf"{self.cw.lineEdit_output_file.text()}"
 
     def append_text(self, text):
         self.cw.textBrowser_log_output.moveCursor(QTextCursor.MoveOperation.End)


### PR DESCRIPTION
Reading paths as raw strings prevents inputs as being treated as escaped characters when using back slashes in paths